### PR TITLE
feat: Persist client drafts & add full onboarding page

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,7 @@ Assistant Rules
 Understand requirements and stack holistically.
 Do not apologize for errors; fix them.
 Ask about stack assumptions if needed.
+**Plan First**: Before implementing any non-trivial change, always present a concise step-by-step plan (files to create/edit, approach, key decisions). Proceed with implementation in the same response after stating the plan.
 Technology Stack
 Frontend: Next.js (React), TypeScript, shadcn/ui (Radix UI), Tailwind CSS, Lucide React.
 Backend: Next.js API Routes (TypeScript).

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,7 +7,7 @@ services:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: boombox
     ports:
-      - "5432:5432"
+      - "5433:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 3001",
     "build": "prisma generate && next build",
     "build:production": "dotenv -e .env.production -- prisma generate && dotenv -e .env.production -- next build",
     "start": "next start",

--- a/src/app/components/modals/AddClientModal.tsx
+++ b/src/app/components/modals/AddClientModal.tsx
@@ -1,9 +1,11 @@
 "use client";
-import React, { useState } from "react";
+// src/app/components/modals/AddClientModal.tsx
+import React, { useState, useEffect, useRef } from "react";
 import {
   UserIcon,
   XMarkIcon,
   CloudArrowUpIcon,
+  BookmarkIcon,
 } from "@heroicons/react/24/solid";
 import {
   NewClientForm,
@@ -14,6 +16,37 @@ import { INITIAL_FORM_STATE } from "../../constants";
 import { Modal, FormField } from "../ui";
 import { useAuth } from "../../hooks/useAuth";
 import { UserAssignmentSelector } from "../client/UserAssignmentSelector";
+
+const SESSION_KEY = "client-onboarding-draft";
+
+interface DraftPayload {
+  formData: NewClientForm;
+  logoPreview: string;
+  currentStep: number;
+  assignedUserIds: number[];
+}
+
+function loadDraft(): DraftPayload | null {
+  try {
+    const raw = sessionStorage.getItem(SESSION_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as DraftPayload;
+  } catch {
+    return null;
+  }
+}
+
+function saveDraft(payload: DraftPayload): void {
+  try {
+    sessionStorage.setItem(SESSION_KEY, JSON.stringify(payload));
+  } catch {
+    // sessionStorage quota exceeded (e.g. large logo) — fail silently
+  }
+}
+
+function clearDraft(): void {
+  sessionStorage.removeItem(SESSION_KEY);
+}
 
 interface AddClientModalProps {
   isOpen: boolean;
@@ -33,6 +66,25 @@ export function AddClientModal({
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [currentStep, setCurrentStep] = useState(0);
   const [assignedUserIds, setAssignedUserIds] = useState<number[]>([]);
+  const [hasDraft, setHasDraft] = useState(false);
+  const prevIsOpen = useRef(false);
+
+  // Restore draft when the modal is opened
+  useEffect(() => {
+    if (isOpen && !prevIsOpen.current) {
+      const draft = loadDraft();
+      if (draft) {
+        setFormData(draft.formData);
+        setLogoPreview(draft.logoPreview ?? "");
+        setCurrentStep(draft.currentStep ?? 0);
+        setAssignedUserIds(draft.assignedUserIds ?? []);
+        setHasDraft(true);
+      } else {
+        setHasDraft(false);
+      }
+    }
+    prevIsOpen.current = isOpen;
+  }, [isOpen]);
 
   const steps = [
     { title: "Basic Information", description: "Company details and logo" },
@@ -56,7 +108,7 @@ export function AddClientModal({
       if (!formData.name.trim()) newErrors.name = "Business name is required";
       if (!formData.industry.trim())
         newErrors.industry = "Industry is required";
-      if (!formData.address.trim()) newErrors.address = "Address is required";
+      if (!formData.address.trim()) newErrors.address = "Business address is required";
     }
 
     setErrors(newErrors);
@@ -80,7 +132,11 @@ export function AddClientModal({
 
     if (currentStep < steps.length - 1) {
       if (validateStep(currentStep)) {
-        setCurrentStep((prev) => prev + 1);
+        const nextStep = currentStep + 1;
+        // Save & Next: persist draft then advance
+        saveDraft({ formData, logoPreview, currentStep: nextStep, assignedUserIds });
+        setCurrentStep(nextStep);
+        setHasDraft(false);
       }
       return;
     }
@@ -107,11 +163,14 @@ export function AddClientModal({
 
       await onSubmit(clientData);
 
+      // Only clear draft on successful final submission
+      clearDraft();
       setFormData(INITIAL_FORM_STATE);
       setLogoPreview("");
       setCurrentStep(0);
       setAssignedUserIds([]);
       setErrors({});
+      setHasDraft(false);
       onClose();
     } catch (error) {
       setErrors({
@@ -134,13 +193,24 @@ export function AddClientModal({
     }
   };
 
+  // Close resets component state but leaves sessionStorage intact for next open
   const handleClose = () => {
     setFormData(INITIAL_FORM_STATE);
     setLogoPreview("");
     setCurrentStep(0);
     setAssignedUserIds([]);
     setErrors({});
+    setHasDraft(false);
     onClose();
+  };
+
+  const handleDiscardDraft = () => {
+    clearDraft();
+    setFormData(INITIAL_FORM_STATE);
+    setLogoPreview("");
+    setCurrentStep(0);
+    setAssignedUserIds([]);
+    setHasDraft(false);
   };
 
   const handleLogoUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -211,6 +281,42 @@ export function AddClientModal({
             />
           </button>
         </div>
+
+        {/* Draft Restored Banner */}
+        {hasDraft && (
+          <div
+            className="flex items-center justify-between mb-4 px-4 py-3 rounded-lg"
+            style={{
+              background: "rgba(59, 130, 246, 0.08)",
+              border: "1px solid rgba(59, 130, 246, 0.25)",
+            }}
+          >
+            <div className="flex items-center space-x-2">
+              <BookmarkIcon className="w-4 h-4" style={{ color: "var(--primary)" }} />
+              <p className="text-sm font-medium" style={{ color: "var(--primary)" }}>
+                Draft restored — you can pick up where you left off.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={handleDiscardDraft}
+              className="text-xs font-medium px-3 py-1 rounded transition-all duration-200"
+              style={{
+                color: "var(--muted)",
+                background: "transparent",
+                border: "1px solid var(--border)",
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.background = "var(--secondary)";
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.background = "transparent";
+              }}
+            >
+              Discard
+            </button>
+          </div>
+        )}
 
         {/* Progress Steps */}
         <div className="flex items-center justify-between mb-8">
@@ -406,7 +512,8 @@ export function AddClientModal({
                   </>
                 ) : currentStep < steps.length - 1 ? (
                   <>
-                    <span>Next</span>
+                    <BookmarkIcon className="w-4 h-4" />
+                    <span>Save &amp; Next</span>
                   </>
                 ) : (
                   <>

--- a/src/app/components/modals/ClientInfoModal.tsx
+++ b/src/app/components/modals/ClientInfoModal.tsx
@@ -6,7 +6,58 @@ import { LoadingSpinner } from "../ui/LoadingSpinner";
 import { EditableField } from "../client/EditableField";
 import { EditableTagField } from "../client/EditableTagField";
 import { BrandAssetsSection } from "../client/BrandAssetsSection";
-import { PencilSquareIcon, CheckCircleIcon, XCircleIcon } from "@heroicons/react/24/solid";
+import { PencilSquareIcon, CheckCircleIcon, XCircleIcon, BookmarkIcon } from "@heroicons/react/24/solid";
+
+// ─── Per-client session draft helpers ─────────────────────────────────────────
+function draftKey(clientId: number) {
+  return `client-info-draft-${clientId}`;
+}
+
+type ClientFormData = ReturnType<typeof buildInitialFormData>;
+
+function buildInitialFormData(client: Client) {
+  return {
+    name: client?.name ?? "",
+    industry: client?.industry ?? "",
+    slogan: client?.slogan ?? "",
+    links: client?.links ?? [],
+    coreProducts: client?.coreProducts ?? [],
+    idealCustomers: client?.idealCustomers ?? "",
+    brandEmotion: client?.brandEmotion ?? "",
+    uniqueProposition: client?.uniqueProposition ?? "",
+    whyChooseUs: client?.whyChooseUs ?? "",
+    mainGoal: client?.mainGoal ?? "",
+    shortTermGoal: client?.shortTermGoal ?? "",
+    longTermGoal: client?.longTermGoal ?? "",
+    competitors: client?.competitors ?? [],
+    indirectCompetitors: client?.indirectCompetitors ?? [],
+    brandAssets: client?.brandAssets ?? [],
+    fontUsed: client?.fontUsed ?? [],
+    smmDriveLink: client?.smmDriveLink ?? "",
+    contractDeliverables: client?.contractDeliverables ?? "",
+  };
+}
+
+function loadClientDraft(clientId: number): ClientFormData | null {
+  try {
+    const raw = sessionStorage.getItem(draftKey(clientId));
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+function saveClientDraft(clientId: number, data: ClientFormData): void {
+  try {
+    sessionStorage.setItem(draftKey(clientId), JSON.stringify(data));
+  } catch {
+    // Quota exceeded — fail silently
+  }
+}
+
+function clearClientDraft(clientId: number): void {
+  sessionStorage.removeItem(draftKey(clientId));
+}
 
 interface ClientInfoModalProps {
   client: Client;
@@ -17,43 +68,54 @@ export function ClientInfoModal({ client }: ClientInfoModalProps) {
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string>("");
+  const [hasDraft, setHasDraft] = useState(false);
 
   const getInitialFormData = useCallback(
-    () => ({
-      name: client?.name ?? "",
-      industry: client?.industry ?? "",
-      slogan: client?.slogan ?? "",
-      links: client?.links ?? [],
-      coreProducts: client?.coreProducts ?? [],
-      idealCustomers: client?.idealCustomers ?? "",
-      brandEmotion: client?.brandEmotion ?? "",
-      uniqueProposition: client?.uniqueProposition ?? "",
-      whyChooseUs: client?.whyChooseUs ?? "",
-      mainGoal: client?.mainGoal ?? "",
-      shortTermGoal: client?.shortTermGoal ?? "",
-      longTermGoal: client?.longTermGoal ?? "",
-      competitors: client?.competitors ?? [],
-      indirectCompetitors: client?.indirectCompetitors ?? [],
-      brandAssets: client?.brandAssets ?? [],
-      fontUsed: client?.fontUsed ?? [],
-      smmDriveLink: client?.smmDriveLink ?? "",
-      contractDeliverables: client?.contractDeliverables ?? "",
-    }),
+    () => buildInitialFormData(client),
     [client]
   );
 
   const [originalFormData, setOriginalFormData] = useState(getInitialFormData);
   const [formData, setFormData] = useState(getInitialFormData);
 
+  // On client change: reset form, then check for a saved draft
   useEffect(() => {
     if (client) {
-      const newFormData = getInitialFormData();
-      setFormData(newFormData);
-      setOriginalFormData(newFormData);
+      const fresh = getInitialFormData();
+      setOriginalFormData(fresh);
       setEditing(false);
       setError("");
+
+      const draft = loadClientDraft(client.id);
+      if (draft) {
+        setFormData(draft);
+        setHasDraft(true);
+      } else {
+        setFormData(fresh);
+        setHasDraft(false);
+      }
     }
   }, [client, getInitialFormData]);
+
+  // Auto-save to session whenever formData changes while editing
+  useEffect(() => {
+    if (editing && client?.id) {
+      saveClientDraft(client.id, formData);
+    }
+  }, [formData, editing, client?.id]);
+
+  const handleRestoreDraft = () => {
+    // Draft is already applied in state; just dismiss the banner and enter edit mode
+    setHasDraft(false);
+    setEditing(true);
+  };
+
+  const handleDiscardDraft = useCallback(() => {
+    if (client?.id) clearClientDraft(client.id);
+    setFormData(originalFormData);
+    setHasDraft(false);
+    setEditing(false);
+  }, [client?.id, originalFormData]);
 
   const handleSave = useCallback(async () => {
     if (!client?.id) return;
@@ -69,8 +131,10 @@ export function ClientInfoModal({ client }: ClientInfoModalProps) {
       };
 
       await updateClient(updatedClient);
+      clearClientDraft(client.id);
       setOriginalFormData(formData);
       setEditing(false);
+      setHasDraft(false);
     } catch (error) {
       if (process.env.NODE_ENV !== "production") {
         console.error("Error updating client:", error);
@@ -86,10 +150,12 @@ export function ClientInfoModal({ client }: ClientInfoModalProps) {
   }, [client, formData, updateClient]);
 
   const handleCancel = useCallback(() => {
+    if (client?.id) clearClientDraft(client.id);
     setFormData(originalFormData);
     setEditing(false);
     setError("");
-  }, [originalFormData]);
+    setHasDraft(false);
+  }, [client?.id, originalFormData]);
 
   const updateField = useCallback(
     (field: string) => (value: any) => {
@@ -101,6 +167,46 @@ export function ClientInfoModal({ client }: ClientInfoModalProps) {
 
   return (
     <div className="w-full relative">
+      {/* Unsaved Draft Banner */}
+      {hasDraft && !editing && (
+        <div
+          className="flex items-center justify-between mb-4 px-4 py-3 rounded-lg"
+          style={{
+            background: "rgba(245, 158, 11, 0.08)",
+            border: "1px solid rgba(245, 158, 11, 0.35)",
+          }}
+        >
+          <div className="flex items-center space-x-2">
+            <BookmarkIcon className="w-4 h-4 flex-shrink-0" style={{ color: "#F59E0B" }} />
+            <p className="text-sm font-medium" style={{ color: "#B45309" }}>
+              You have unsaved changes from a previous session.
+            </p>
+          </div>
+          <div className="flex items-center gap-2 ml-4 flex-shrink-0">
+            <button
+              type="button"
+              onClick={handleDiscardDraft}
+              className="text-xs font-medium px-3 py-1 rounded transition-all duration-200"
+              style={{ color: "var(--muted)", background: "transparent", border: "1px solid var(--border)" }}
+              onMouseEnter={(e) => { e.currentTarget.style.background = "var(--secondary)"; }}
+              onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; }}
+            >
+              Discard
+            </button>
+            <button
+              type="button"
+              onClick={handleRestoreDraft}
+              className="text-xs font-medium px-3 py-1 rounded transition-all duration-200"
+              style={{ color: "var(--primary-foreground)", background: "var(--primary)" }}
+              onMouseEnter={(e) => { e.currentTarget.style.background = "#1E40AF"; }}
+              onMouseLeave={(e) => { e.currentTarget.style.background = "var(--primary)"; }}
+            >
+              Resume editing
+            </button>
+          </div>
+        </div>
+      )}
+
       {/* Header */}
       <div className="flex items-center justify-end mb-6">
         <div className="flex items-center gap-2">

--- a/src/app/dashboard/add-new-client/page.tsx
+++ b/src/app/dashboard/add-new-client/page.tsx
@@ -1,0 +1,587 @@
+// src/app/dashboard/add-new-client/page.tsx
+// Full-page version of the client onboarding form.
+// Inherits sidebar + navbar from DashboardLayout automatically.
+"use client";
+import React, { useState, useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
+import {
+  UserIcon,
+  XMarkIcon,
+  CloudArrowUpIcon,
+  BookmarkIcon,
+} from "@heroicons/react/24/solid";
+import {
+  NewClientForm,
+  arrayFieldToString,
+  stringToArrayField,
+} from "../../types";
+import { INITIAL_FORM_STATE } from "../../constants";
+import { FormField } from "../../components/ui";
+import { useAuth } from "../../hooks/useAuth";
+import { useClientManagement } from "../../hooks";
+import { UserAssignmentSelector } from "../../components/client/UserAssignmentSelector";
+
+// ─── Session draft helpers ────────────────────────────────────────────────────
+const SESSION_KEY = "client-onboarding-draft";
+
+interface DraftPayload {
+  formData: NewClientForm;
+  logoPreview: string;
+  currentStep: number;
+  assignedUserIds: number[];
+}
+
+function loadDraft(): DraftPayload | null {
+  try {
+    const raw = sessionStorage.getItem(SESSION_KEY);
+    return raw ? (JSON.parse(raw) as DraftPayload) : null;
+  } catch {
+    return null;
+  }
+}
+
+function saveDraft(payload: DraftPayload): void {
+  try {
+    sessionStorage.setItem(SESSION_KEY, JSON.stringify(payload));
+  } catch {
+    // Quota exceeded (e.g. large logo) — fail silently
+  }
+}
+
+function clearDraft(): void {
+  sessionStorage.removeItem(SESSION_KEY);
+}
+
+// ─── Page component ───────────────────────────────────────────────────────────
+export default function AddNewClientPage() {
+  const router = useRouter();
+  const { authState } = useAuth();
+  const { addClient } = useClientManagement();
+
+  const [formData, setFormData] = useState<NewClientForm>(INITIAL_FORM_STATE);
+  const [logoPreview, setLogoPreview] = useState<string>("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [currentStep, setCurrentStep] = useState(0);
+  const [assignedUserIds, setAssignedUserIds] = useState<number[]>([]);
+  const [hasDraft, setHasDraft] = useState(false);
+  const mounted = useRef(false);
+
+  // Restore draft on first mount
+  useEffect(() => {
+    if (!mounted.current) {
+      mounted.current = true;
+      const draft = loadDraft();
+      if (draft) {
+        setFormData(draft.formData);
+        setLogoPreview(draft.logoPreview ?? "");
+        setCurrentStep(draft.currentStep ?? 0);
+        setAssignedUserIds(draft.assignedUserIds ?? []);
+        setHasDraft(true);
+      }
+    }
+  }, []);
+
+  const steps = [
+    { title: "Basic Information", description: "Company details and logo" },
+    { title: "Business Details", description: "Products, customers, and goals" },
+    { title: "Competition & Branding", description: "Competitors and brand assets" },
+  ];
+
+  const canAssignSMMs =
+    authState.user?.role === "ADMIN" || authState.user?.role === "SUPER_ADMIN";
+
+  const validateStep = (step: number): boolean => {
+    const newErrors: Record<string, string> = {};
+    if (step === 0) {
+      if (!formData.name.trim()) newErrors.name = "Business name is required";
+      if (!formData.industry.trim()) newErrors.industry = "Industry is required";
+      if (!formData.address.trim()) newErrors.address = "Business address is required";
+    }
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const safeStringToArray = (value: string | string[] | undefined): string[] => {
+    if (Array.isArray(value)) return value;
+    if (typeof value === "string") return stringToArrayField(value);
+    return [];
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (currentStep < steps.length - 1) {
+      if (validateStep(currentStep)) {
+        const nextStep = currentStep + 1;
+        saveDraft({ formData, logoPreview, currentStep: nextStep, assignedUserIds });
+        setCurrentStep(nextStep);
+        setHasDraft(false);
+      }
+      return;
+    }
+
+    if (!validateStep(currentStep)) return;
+
+    setIsLoading(true);
+    setErrors({});
+
+    try {
+      const clientData: NewClientForm = {
+        ...formData,
+        logo: logoPreview || null,
+        links: safeStringToArray(formData.links),
+        coreProducts: safeStringToArray(formData.coreProducts),
+        competitors: safeStringToArray(formData.competitors),
+        indirectCompetitors: safeStringToArray(formData.indirectCompetitors),
+        fontUsed: safeStringToArray(formData.fontUsed),
+        brandAssets: Array.isArray(formData.brandAssets) ? formData.brandAssets : [],
+        assignedUserIds,
+      };
+
+      await addClient(clientData);
+
+      // Clear draft only on success
+      clearDraft();
+      router.push("/dashboard");
+    } catch (error) {
+      setErrors({
+        submit: error instanceof Error ? error.message : "Failed to create client",
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const updateFormField = (field: keyof NewClientForm) => (value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+    if (errors[field]) {
+      setErrors((prev) => {
+        const next = { ...prev };
+        delete next[field];
+        return next;
+      });
+    }
+  };
+
+  const handleCancel = () => {
+    router.back();
+  };
+
+  const handleDiscardDraft = () => {
+    clearDraft();
+    setFormData(INITIAL_FORM_STATE);
+    setLogoPreview("");
+    setCurrentStep(0);
+    setAssignedUserIds([]);
+    setHasDraft(false);
+  };
+
+  const handleLogoUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (file.size > 5 * 1024 * 1024) {
+      setErrors((prev) => ({ ...prev, logo: "Logo file must be smaller than 5MB" }));
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      const result = event.target?.result as string;
+      setLogoPreview(result);
+      setErrors((prev) => { const n = { ...prev }; delete n.logo; return n; });
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const prevStep = () => setCurrentStep((prev) => Math.max(prev - 1, 0));
+
+  return (
+    <div className="max-w-4xl mx-auto py-8">
+      {/* Page Header */}
+      <div className="mb-6">
+        <h1
+          className="text-3xl font-bold tracking-tight mb-1"
+          style={{ color: "var(--card-foreground)" }}
+        >
+          Add New Client
+        </h1>
+        <p className="text-sm" style={{ color: "var(--muted)" }}>
+          Complete the onboarding form to create a new client profile.
+        </p>
+      </div>
+
+      {/* Card wrapper */}
+      <div
+        className="rounded-xl p-8"
+        style={{
+          background: "var(--card)",
+          border: "1px solid var(--border)",
+        }}
+      >
+        {/* Draft Restored Banner */}
+        {hasDraft && (
+          <div
+            className="flex items-center justify-between mb-6 px-4 py-3 rounded-lg"
+            style={{
+              background: "rgba(59, 130, 246, 0.08)",
+              border: "1px solid rgba(59, 130, 246, 0.25)",
+            }}
+          >
+            <div className="flex items-center space-x-2">
+              <BookmarkIcon className="w-4 h-4" style={{ color: "var(--primary)" }} />
+              <p className="text-sm font-medium" style={{ color: "var(--primary)" }}>
+                Draft restored — you can pick up where you left off.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={handleDiscardDraft}
+              className="text-xs font-medium px-3 py-1 rounded transition-all duration-200"
+              style={{ color: "var(--muted)", background: "transparent", border: "1px solid var(--border)" }}
+              onMouseEnter={(e) => { e.currentTarget.style.background = "var(--secondary)"; }}
+              onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; }}
+            >
+              Discard
+            </button>
+          </div>
+        )}
+
+        {/* Progress Steps */}
+        <div className="flex items-center justify-between mb-8">
+          {steps.map((step, index) => (
+            <div key={index} className="flex items-center flex-1">
+              <div className="flex items-center">
+                <div
+                  className="w-10 h-10 rounded-full flex items-center justify-center text-sm font-bold transition-all duration-200"
+                  style={{
+                    background: index <= currentStep ? "var(--primary)" : "var(--secondary)",
+                    color: index <= currentStep ? "var(--primary-foreground)" : "var(--muted)",
+                  }}
+                >
+                  {index + 1}
+                </div>
+                <div className="ml-3 hidden sm:block">
+                  <p
+                    className="text-sm font-medium"
+                    style={{ color: index <= currentStep ? "var(--card-foreground)" : "var(--muted)" }}
+                  >
+                    {step.title}
+                  </p>
+                  <p className="text-xs" style={{ color: "var(--muted)" }}>
+                    {step.description}
+                  </p>
+                </div>
+              </div>
+              {index < steps.length - 1 && (
+                <div
+                  className="flex-1 h-0.5 mx-4 transition-all duration-200"
+                  style={{ background: index < currentStep ? "var(--primary)" : "var(--border)" }}
+                />
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* Submit error */}
+        {errors.submit && (
+          <div
+            className="mb-6 p-4 rounded-lg"
+            style={{
+              background: "rgba(239, 68, 68, 0.1)",
+              border: "1px solid rgba(239, 68, 68, 0.3)",
+            }}
+          >
+            <p className="text-sm" style={{ color: "var(--danger)" }}>
+              {errors.submit}
+            </p>
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-6">
+          {/* Step 0 */}
+          {currentStep === 0 && (
+            <div className="space-y-6">
+              <LogoUploadSection
+                logoPreview={logoPreview}
+                onLogoUpload={handleLogoUpload}
+                setLogoPreview={setLogoPreview}
+                formData={formData}
+                updateFormField={updateFormField}
+                errors={errors}
+              />
+              <BasicInfoSection formData={formData} updateFormField={updateFormField} errors={errors} />
+              {canAssignSMMs && (
+                <AssignmentSection assignedUserIds={assignedUserIds} setAssignedUserIds={setAssignedUserIds} />
+              )}
+            </div>
+          )}
+
+          {/* Step 1 */}
+          {currentStep === 1 && (
+            <BusinessDetailsSection formData={formData} updateFormField={updateFormField} errors={errors} />
+          )}
+
+          {/* Step 2 */}
+          {currentStep === 2 && (
+            <div className="space-y-6">
+              <CompetitionSection formData={formData} updateFormField={updateFormField} errors={errors} />
+              <BrandingSection formData={formData} updateFormField={updateFormField} errors={errors} />
+            </div>
+          )}
+
+          {/* Navigation */}
+          <div
+            className="flex items-center justify-between pt-6 border-t"
+            style={{ borderColor: "var(--border)" }}
+          >
+            <button
+              type="button"
+              onClick={prevStep}
+              disabled={currentStep === 0}
+              className="px-6 py-2 rounded-lg font-medium transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+              style={{
+                background: "var(--secondary)",
+                color: "var(--card-foreground)",
+                border: "1px solid var(--border)",
+              }}
+              onMouseEnter={(e) => { if (currentStep !== 0) e.currentTarget.style.background = "var(--background)"; }}
+              onMouseLeave={(e) => { if (currentStep !== 0) e.currentTarget.style.background = "var(--secondary)"; }}
+            >
+              Previous
+            </button>
+
+            <div className="flex space-x-3">
+              <button
+                type="button"
+                onClick={handleCancel}
+                className="px-6 py-2 rounded-lg font-medium transition-all duration-200"
+                style={{
+                  background: "var(--secondary)",
+                  color: "var(--card-foreground)",
+                  border: "1px solid var(--border)",
+                }}
+                onMouseEnter={(e) => { e.currentTarget.style.background = "var(--background)"; }}
+                onMouseLeave={(e) => { e.currentTarget.style.background = "var(--secondary)"; }}
+              >
+                Cancel
+              </button>
+
+              <button
+                type="submit"
+                disabled={isLoading}
+                className="px-6 py-2 rounded-lg font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200 flex items-center space-x-2"
+                style={{ background: "var(--primary)", color: "var(--primary-foreground)" }}
+                onMouseEnter={(e) => { if (!isLoading) e.currentTarget.style.background = "#1E40AF"; }}
+                onMouseLeave={(e) => { e.currentTarget.style.background = "var(--primary)"; }}
+              >
+                {isLoading ? (
+                  <>
+                    <div
+                      className="w-4 h-4 rounded-full animate-spin"
+                      style={{ border: "2px solid rgba(255,255,255,0.3)", borderTopColor: "#fff" }}
+                    />
+                    <span>Creating...</span>
+                  </>
+                ) : currentStep < steps.length - 1 ? (
+                  <>
+                    <BookmarkIcon className="w-4 h-4" />
+                    <span>Save &amp; Next</span>
+                  </>
+                ) : (
+                  <>
+                    <CloudArrowUpIcon className="w-5 h-5" />
+                    <span>Create Client</span>
+                  </>
+                )}
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+interface SectionProps {
+  formData: NewClientForm;
+  updateFormField: (field: keyof NewClientForm) => (value: string) => void;
+  errors: Record<string, string>;
+}
+
+interface LogoSectionProps extends SectionProps {
+  logoPreview: string;
+  onLogoUpload: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  setLogoPreview: React.Dispatch<React.SetStateAction<string>>;
+}
+
+function LogoUploadSection({ logoPreview, onLogoUpload, setLogoPreview, formData, updateFormField, errors }: LogoSectionProps) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
+      <div className="flex flex-col items-center space-y-3">
+        <div className="relative">
+          <div
+            className="w-20 h-20 rounded-full border-2 border-dashed flex items-center justify-center overflow-hidden transition-all duration-200"
+            style={{ background: "var(--background)", borderColor: "var(--border)" }}
+            onMouseEnter={(e) => { e.currentTarget.style.borderColor = "var(--primary)"; }}
+            onMouseLeave={(e) => { e.currentTarget.style.borderColor = "var(--border)"; }}
+          >
+            {logoPreview ? (
+              <img src={logoPreview} alt="Logo Preview" className="w-full h-full object-cover" />
+            ) : (
+              <UserIcon className="w-10 h-10" style={{ color: "var(--muted)" }} />
+            )}
+          </div>
+          {logoPreview && (
+            <button
+              type="button"
+              onClick={() => setLogoPreview("")}
+              className="absolute -top-2 -right-2 w-6 h-6 rounded-full flex items-center justify-center transition-all duration-200"
+              style={{ background: "var(--danger)" }}
+              onMouseEnter={(e) => { e.currentTarget.style.background = "#DC2626"; }}
+              onMouseLeave={(e) => { e.currentTarget.style.background = "var(--danger)"; }}
+            >
+              <XMarkIcon className="w-4 h-4 text-white" />
+            </button>
+          )}
+        </div>
+
+        <input type="file" accept="image/*" className="hidden" id="client-logo-upload" onChange={onLogoUpload} />
+        <label
+          htmlFor="client-logo-upload"
+          className="px-4 py-2 text-sm font-medium rounded-lg cursor-pointer transition-all duration-200"
+          style={{ background: "var(--primary)", color: "var(--primary-foreground)" }}
+          onMouseEnter={(e) => { e.currentTarget.style.background = "#1E40AF"; }}
+          onMouseLeave={(e) => { e.currentTarget.style.background = "var(--primary)"; }}
+        >
+          Upload Logo
+        </label>
+        {errors.logo && (
+          <p className="text-xs text-center" style={{ color: "var(--danger)" }}>{errors.logo}</p>
+        )}
+      </div>
+
+      <div className="md:col-span-3 space-y-4">
+        <FormField
+          label="Business Name *"
+          placeholder="Enter company name"
+          value={formData.name}
+          onChange={updateFormField("name")}
+          error={errors.name}
+        />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <FormField
+            label="Industry *"
+            placeholder="e.g., Technology, Healthcare"
+            value={formData.industry}
+            onChange={updateFormField("industry")}
+            error={errors.industry}
+          />
+          <FormField
+            label="Business Address *"
+            placeholder="City, Country"
+            value={formData.address}
+            onChange={updateFormField("address")}
+            error={errors.address}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BasicInfoSection({ formData, updateFormField, errors }: SectionProps) {
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold" style={{ color: "var(--card-foreground)" }}>
+        Additional Information
+      </h3>
+      <FormField label="Slogan" placeholder="Your inspiring tagline" value={formData.slogan || ""} onChange={updateFormField("slogan")} error={errors.slogan} />
+      <FormField
+        label="Social Media & Website Links"
+        placeholder="https://website.com, https://facebook.com/page"
+        value={arrayFieldToString(formData.links)}
+        onChange={updateFormField("links")}
+        error={errors.links}
+        multiline
+        rows={2}
+      />
+      <FormField
+        label="Core Products/Services"
+        placeholder="Product A, Service B, Solution C"
+        value={arrayFieldToString(formData.coreProducts)}
+        onChange={updateFormField("coreProducts")}
+        error={errors.coreProducts}
+        multiline
+        rows={2}
+      />
+    </div>
+  );
+}
+
+function BusinessDetailsSection({ formData, updateFormField, errors }: SectionProps) {
+  return (
+    <div className="space-y-6">
+      <h3 className="text-lg font-semibold" style={{ color: "var(--card-foreground)" }}>
+        Business Strategy &amp; Goals
+      </h3>
+      <div className="grid grid-cols-1 gap-4">
+        <FormField label="Ideal Customers" placeholder="Describe your target audience" value={formData.idealCustomers || ""} onChange={updateFormField("idealCustomers")} error={errors.idealCustomers} multiline rows={3} />
+        <FormField label="Brand Emotion" placeholder="What feeling should your brand evoke?" value={formData.brandEmotion || ""} onChange={updateFormField("brandEmotion")} error={errors.brandEmotion} />
+        <FormField label="Unique Value Proposition" placeholder="What makes your business unique?" value={formData.uniqueProposition || ""} onChange={updateFormField("uniqueProposition")} error={errors.uniqueProposition} multiline rows={3} />
+        <FormField label="Why Choose Us" placeholder="Why should customers choose you?" value={formData.whyChooseUs || ""} onChange={updateFormField("whyChooseUs")} error={errors.whyChooseUs} multiline rows={3} />
+      </div>
+      <h4 className="text-md font-semibold mt-6" style={{ color: "var(--card-foreground)" }}>Business Goals</h4>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <FormField label="Main Goal" placeholder="Primary business objective" value={formData.mainGoal || ""} onChange={updateFormField("mainGoal")} error={errors.mainGoal} multiline rows={2} />
+        <FormField label="Short Term Goal" placeholder="Goals for next 6-12 months" value={formData.shortTermGoal || ""} onChange={updateFormField("shortTermGoal")} error={errors.shortTermGoal} multiline rows={2} />
+        <FormField label="Long Term Goal" placeholder="Goals for next 2-5 years" value={formData.longTermGoal || ""} onChange={updateFormField("longTermGoal")} error={errors.longTermGoal} multiline rows={2} />
+      </div>
+    </div>
+  );
+}
+
+function CompetitionSection({ formData, updateFormField, errors }: SectionProps) {
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold" style={{ color: "var(--card-foreground)" }}>Competition Analysis</h3>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <FormField label="Direct Competitors" placeholder="Company A, Company B" value={arrayFieldToString(formData.competitors)} onChange={updateFormField("competitors")} error={errors.competitors} multiline rows={3} />
+        <FormField label="Indirect Competitors" placeholder="Alternative solutions or substitutes" value={arrayFieldToString(formData.indirectCompetitors)} onChange={updateFormField("indirectCompetitors")} error={errors.indirectCompetitors} multiline rows={3} />
+      </div>
+    </div>
+  );
+}
+
+function BrandingSection({ formData, updateFormField, errors }: SectionProps) {
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold" style={{ color: "var(--card-foreground)" }}>Branding &amp; Assets</h3>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <FormField label="Fonts Used" placeholder="Arial, Roboto, Open Sans" value={arrayFieldToString(formData.fontUsed)} onChange={updateFormField("fontUsed")} error={errors.fontUsed} />
+        <FormField label="SMM Drive Link" placeholder="https://drive.google.com/..." value={formData.smmDriveLink || ""} onChange={updateFormField("smmDriveLink")} error={errors.smmDriveLink} />
+      </div>
+      <FormField label="Contract Deliverables" placeholder="Monthly posts, weekly reports, etc." value={formData.contractDeliverables || ""} onChange={updateFormField("contractDeliverables")} error={errors.contractDeliverables} multiline rows={3} />
+    </div>
+  );
+}
+
+interface AssignmentSectionProps {
+  assignedUserIds: number[];
+  setAssignedUserIds: React.Dispatch<React.SetStateAction<number[]>>;
+}
+
+function AssignmentSection({ assignedUserIds, setAssignedUserIds }: AssignmentSectionProps) {
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold" style={{ color: "var(--card-foreground)" }}>SMM Assignment</h3>
+      <p className="text-sm" style={{ color: "var(--muted)" }}>
+        Select which Social Media Managers should be assigned to this client. Leave empty to assign later.
+      </p>
+      <div className="rounded-lg p-4" style={{ background: "var(--background)", border: "1px solid var(--border)" }}>
+        <UserAssignmentSelector initialAssignedUserIds={assignedUserIds} onChange={setAssignedUserIds} canEdit={true} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,9 +1,7 @@
 "use client";
 import React, { useState } from "react";
-import { usePathname } from "next/navigation";
-import { useClientManagement, useModal } from "../hooks";
-import { NewClientForm } from "../types";
-import { AddClientModal } from "../components/modals/AddClientModal";
+import { usePathname, useRouter } from "next/navigation";
+import { useClientManagement } from "../hooks";
 import { SidePanel } from "../components/sidebar/SidePanel";
 import { Navbar } from "../components/header/Navbar";
 
@@ -12,13 +10,8 @@ export default function DashboardLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const { clients, addClient, isLoading, error, loadClients } =
-    useClientManagement();
-  const {
-    isOpen: isModalOpen,
-    open: openModal,
-    close: closeModal,
-  } = useModal();
+  const { clients, isLoading, error, loadClients } = useClientManagement();
+  const router = useRouter();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [sidebarMobileOpen, setSidebarMobileOpen] = useState(false);
 
@@ -42,7 +35,7 @@ export default function DashboardLayout({
           setSidebarCollapsed(!sidebarCollapsed);
         }}
         clients={clients}
-        onAddClientClick={openModal}
+        onAddClientClick={() => router.push("/dashboard/add-new-client")}
         isLoading={isLoading}
         error={error}
         mobileOpen={sidebarMobileOpen}
@@ -66,15 +59,6 @@ export default function DashboardLayout({
       >
         {children}
       </main>
-
-      <AddClientModal
-        isOpen={isModalOpen}
-        onClose={closeModal}
-        onSubmit={async (clientData: NewClientForm) => {
-          await addClient(clientData);
-          closeModal();
-        }}
-      />
     </div>
   );
 }


### PR DESCRIPTION
Add session draft save/restore for client onboarding and client info flows, and introduce a full-page onboarding form.

- Add sessionStorage helpers and UI: save/load/clear draft for onboarding (key: "client-onboarding-draft") and per-client edits (keys: "client-info-draft-{id}").
- Enhance AddClientModal: restore drafts on open, show restored banner with Discard option, save draft on "Save & Next", clear only on successful final submit, autosave-related UX tweaks and small validation copy change ("Business address").
- Add a full-page onboarding implementation at src/app/dashboard/add-new-client/page.tsx with the same draft behavior and step navigation.
- Add client-info draft autosave in ClientInfoModal with Resume/Discard banner and clear-on-save/cancel behavior.
- Update dashboard layout: remove modal usage and route the sidebar Add button to the new /dashboard/add-new-client page.
- Minor infra tweaks: change compose.yaml postgres host mapping to "5433:5432" and run dev server on port 3001 (package.json dev script).
- Update .github/copilot-instructions.md to add a "Plan First" guideline.

Notes: Drafts are persisted to sessionStorage and are cleared only on successful submission or when the user discards them.